### PR TITLE
Refactor accessibility service for compilation errors

### DIFF
--- a/app/src/main/java/com/aiwriter/assistant/service/AccessibilityService.kt
+++ b/app/src/main/java/com/aiwriter/assistant/service/AccessibilityService.kt
@@ -23,7 +23,23 @@ class AccessibilityService : AccessibilityService() {
          */
         fun insertText(text: String): Boolean {
             val service = getInstance()
-            return service?.insertTextInternal(text) ?: false
+            return if (service != null) {
+                // 直接在companion object中处理文本插入逻辑
+                try {
+                    val focusedNode = findFocusedEditableNode(service.rootInActiveWindow)
+                    if (focusedNode != null) {
+                        insertTextToNode(service, focusedNode, text)
+                        return true
+                    }
+                    // 找不到输入框，使用剪贴板
+                    copyToClipboard(service, text)
+                    true
+                } catch (e: Exception) {
+                    false
+                }
+            } else {
+                false
+            }
         }
 
         /**
@@ -33,6 +49,47 @@ class AccessibilityService : AccessibilityService() {
             val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
             val clip = ClipData.newPlainText("AI Writing Assistant", text)
             clipboard.setPrimaryClip(clip)
+        }
+
+        /**
+         * 递归查找当前窗口中获得焦点且可编辑的节点
+         */
+        private fun findFocusedEditableNode(root: AccessibilityNodeInfo?): AccessibilityNodeInfo? {
+            root ?: return null
+            if (root.isFocused && root.isEditable) return root
+            for (i in 0 until root.childCount) {
+                val child = root.getChild(i)
+                child?.let {
+                    val found = findFocusedEditableNode(it)
+                    if (found != null) {
+                        it.recycle()
+                        return found
+                    }
+                    it.recycle()
+                }
+            }
+            return null
+        }
+
+        /**
+         * 向指定节点插入文本
+         */
+        private fun insertTextToNode(service: AccessibilityService, node: AccessibilityNodeInfo, text: String): Boolean {
+            return try {
+                val arguments = bundleOf(
+                    AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE to text
+                )
+                val success = node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments)
+                if (!success) {
+                    // 兼容性处理：用剪贴板粘贴
+                    copyToClipboard(service, text)
+                    node.performAction(AccessibilityNodeInfo.ACTION_PASTE)
+                } else {
+                    true
+                }
+            } catch (e: Exception) {
+                false
+            }
         }
     }
 
@@ -52,64 +109,5 @@ class AccessibilityService : AccessibilityService() {
 
     override fun onInterrupt() {
         // 服务中断处理
-    }
-
-    /**
-     * 内部方法：插入文本到当前焦点输入框
-     */
-    internal fun insertTextInternal(text: String): Boolean {
-        return try {
-            val focusedNode = findFocusedEditableNode(rootInActiveWindow)
-            if (focusedNode != null) {
-                insertTextToNode(focusedNode, text)
-                return true
-            }
-            // 找不到输入框，使用剪贴板
-            copyToClipboard(this, text)
-            true
-        } catch (e: Exception) {
-            false
-        }
-    }
-
-    /**
-     * 递归查找当前窗口中获得焦点且可编辑的节点
-     */
-    private fun findFocusedEditableNode(root: AccessibilityNodeInfo?): AccessibilityNodeInfo? {
-        root ?: return null
-        if (root.isFocused && root.isEditable) return root
-        for (i in 0 until root.childCount) {
-            val child = root.getChild(i)
-            child?.let {
-                val found = findFocusedEditableNode(it)
-                if (found != null) {
-                    it.recycle()
-                    return found
-                }
-                it.recycle()
-            }
-        }
-        return null
-    }
-
-    /**
-     * 向指定节点插入文本
-     */
-    private fun insertTextToNode(node: AccessibilityNodeInfo, text: String): Boolean {
-        return try {
-            val arguments = bundleOf(
-                AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE to text
-            )
-            val success = node.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, arguments)
-            if (!success) {
-                // 兼容性处理：用剪贴板粘贴
-                copyToClipboard(this, text)
-                node.performAction(AccessibilityNodeInfo.ACTION_PASTE)
-            } else {
-                true
-            }
-        } catch (e: Exception) {
-            false
-        }
     }
 }


### PR DESCRIPTION
Refactor `AccessibilityService` to move text insertion logic to companion object static methods, resolving "Unresolved reference" errors.

The previous implementation attempted to call instance methods (`insertTextInternal`) from within the `companion object`'s `insertText` method. Kotlin's access rules prevent companion objects from directly accessing instance methods, even if they are `internal`, leading to compilation failures. This refactoring resolves the access permission issue by making all relevant text insertion logic static within the companion object.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1655c49-f84f-4ed6-9921-f7cc99c42b0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1655c49-f84f-4ed6-9921-f7cc99c42b0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

